### PR TITLE
Define DB syncer resources at the Cache CR level

### DIFF
--- a/config/cache/v1alpha1/cache.proto
+++ b/config/cache/v1alpha1/cache.proto
@@ -9,9 +9,56 @@ option java_multiple_files = true;
 // Describes the desired configuration for a Cache. Only DB Cache Service is supported atm
 message CacheSpec {
   // Resource profile for the cache provider
-  Resources resources = 1;
+  CacheDeploymentSpec deployment = 1;
+  // Resource profile for the db-syncer
+  DBSyncerDeploymentSpec dbSyncer = 2;
   // DatasourceRef or a ServiceBindingRef (TODO clarify)
-  DataSourceSpec dataSource = 2;
+  DataSourceSpec dataSource = 3;
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// Describes the spec of the cache provider
+message CacheDeploymentSpec {
+  // The type of Cache deployment
+  CacheDeploymentType type = 1;
+  // Resource profile for cache pods
+  Resources resource = 2;
+  // Max number of replicas for type CLUSTER
+  int32 replicas = 3;
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// Describes the spec of the db-syncer deployment
+message DBSyncerDeploymentSpec {
+  // Resource profile for db-syncer pods
+  Resources resources = 1;
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// The type of cache deployment
+enum CacheDeploymentType {
+  LOCAL = 0;
+  CLUSTER = 1;
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// Describes a resources profile required for a workload
+message Resources {
+  ResourceQuantity requests = 1;
+  ResourceQuantity limits = 2;
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// Describes a resource quantities
+message ResourceQuantity {
+  // TODO: use the k8s type for quantity. Check the Java side
+  // k8s.io.apimachinery.pkg.api.resource.Quantity memory = 1;
+  // Memory quantity
+  string memory = 1;
+  // TODO: use the k8s type for quantity. Check the Java side
+  // k8s.io.apimachinery.pkg.api.resource.Quantity cpu = 2;
+  // CPU quantity
+  string cpu = 2;
 }
 
 // Document representation of a cache and all the related rules

--- a/config/cache/v1alpha1/rules.proto
+++ b/config/cache/v1alpha1/rules.proto
@@ -22,15 +22,13 @@ message DataSourceSpec {
   message EagerCacheRuleSpec {
     // Reference to the related Cache CR
     NamespacedRef  cacheRef = 1;
-    // Resource profile for the DB syncer
-    Resources resources = 2;
     // Name of the table from where the data will be produced. Format could change depending
     // on the DB: table or schema.table must be at least supported
-    string tableName = 3;
+    string tableName = 2;
     // Format of the key for the get(key) operation
-    Key key = 4;
+    Key key = 3;
     // Query columns used to build the entry value
-    Value value = 5;
+    Value value = 4;
   }
   
   // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -59,26 +57,6 @@ message DataSourceSpec {
   message Value {
     // Table columns that will be fetched from the DB (select clause)
     repeated string valueColumns = 1;
-  }
-  
-  // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-  // Describes a resources profile required for a workload
-  message Resources {
-    ResourceQuantity requests = 1;
-    ResourceQuantity limits = 2;
-  }
-  
-  // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-  // Describes a resource quantities
-  message ResourceQuantity {
-    // TODO: use the k8s type for quantity. Check the Java side
-    // k8s.io.apimachinery.pkg.api.resource.Quantity memory = 1;
-    // Memory quantity
-    string memory = 1;
-    // TODO: use the k8s type for quantity. Check the Java side
-    // k8s.io.apimachinery.pkg.api.resource.Quantity cpu = 2;
-    // CPU quantity
-    string cpu = 2;
   }
   
   // A namespaced reference to a resource


### PR DESCRIPTION
@rigazilla This is needed as we now plan to have a single DB syncer deployment per cache instead of one per  rule. 

I wasn't sure how best to test this with the operator generate code git submodule, I'll ping you on Monday for details.