### PR TITLE
added applygingersnapstyle-gen

### DIFF
--- a/cmd/applygingersnapstyle-gen/go.mod
+++ b/cmd/applygingersnapstyle-gen/go.mod
@@ -1,0 +1,8 @@
+module github.com/gingersnap-api/cmd/applygingersnapstyle-gen
+
+go 1.18
+
+require (
+	github.com/fatih/structtag v1.2.0
+	github.com/iancoleman/strcase v0.2.0
+)

--- a/cmd/applygingersnapstyle-gen/go.sum
+++ b/cmd/applygingersnapstyle-gen/go.sum
@@ -1,0 +1,4 @@
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/cmd/applygingersnapstyle-gen/main.go
+++ b/cmd/applygingersnapstyle-gen/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+
+	"github.com/fatih/structtag"
+	"github.com/iancoleman/strcase"
+)
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+	fset := token.NewFileSet()
+
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "error: missing arguments, infile outfile needed\n")
+		os.Exit(1)
+	}
+	fileName := args[0]
+	outFile, err := os.Create(args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	// get ast Node of whole file;
+	ff, err := parser.ParseFile(fset, fileName, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	var v visitor
+	ast.Walk(v, ff)
+	if err := format.Node(outFile, fset, ff); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+
+	}
+}
+
+type visitor struct{}
+
+func (v visitor) Visit(n ast.Node) ast.Visitor {
+	if n == nil {
+		return nil
+	}
+	switch field := n.(type) {
+	case *ast.Field:
+		if tag := field.Tag; tag != nil {
+			tags, _ := structtag.Parse(strings.Trim(field.Tag.Value, "`"))
+			for i := range tags.Tags() {
+				if tags.Tags()[i].Key == "json" {
+					tags.Tags()[i].Name = strcase.ToLowerCamel(tags.Tags()[i].Name)
+				}
+				field.Tag.Value = "`" + tags.String() + "`"
+			}
+		}
+	}
+	return v
+}


### PR DESCRIPTION
adding a code generator that applies Gingersnap code style.
Initially conceived to fix json tag names for protobuf field (we want camels not snakes), it can be easily extended with other customization if needed.